### PR TITLE
Upgrade deprecated runtime python3.7

### DIFF
--- a/aws-cloudknox-config/cft/aws-cloudknox-configremediation.yaml
+++ b/aws-cloudknox-config/cft/aws-cloudknox-configremediation.yaml
@@ -45,7 +45,7 @@ Resources:
       Description: CloudKnox IAM User Rightsizing Lambda
       Handler: CloudKnox_IAMRightsize.lambda_handler
       MemorySize: '256'
-      Runtime: python3.7
+      Runtime: python3.10
       Timeout: 300
 
 #CloudKnox IAM Rightsize Lambda Role

--- a/aws-cloudknox-config/cft/aws-cloudknox-custom-config-rule.yml
+++ b/aws-cloudknox-config/cft/aws-cloudknox-custom-config-rule.yml
@@ -54,7 +54,7 @@ Parameters:
     Type: String
     MinLength: '1'
     MaxLength: '255'
-    Default: 'python3.7'
+    Default: 'python3.10'
   SourcePeriodic:
     Description: Execution Frequency
     Type: String

--- a/aws-cloudknox-config/configrule/parameters.json
+++ b/aws-cloudknox-config/configrule/parameters.json
@@ -2,7 +2,7 @@
   "Version": "1.0",
   "Parameters": {
     "RuleName": "CLOUDKNOX_PCI",
-    "SourceRuntime": "python3.7",
+    "SourceRuntime": "python3.10",
     "CodeKey": "CLOUDKNOX_PCI.zip",
     "InputParameters": "{}",
     "OptionalParameters": "{}",

--- a/aws-cloudknox-config/document/ck_right_size_runbook.yaml
+++ b/aws-cloudknox-config/document/ck_right_size_runbook.yaml
@@ -14,7 +14,7 @@ mainSteps:
   - name: ck_right_size_ssm_doc
     action: aws:executeScript
     inputs:
-      Runtime: python3.7
+      Runtime: python3.10
       Handler: ck_right_size.handler
       InputPayload:
         username: '{{username}}'

--- a/aws-cloudknox-controltower/cft/aws-cloudknox-controltower.yaml
+++ b/aws-cloudknox-controltower/cft/aws-cloudknox-controltower.yaml
@@ -228,7 +228,7 @@ Resources:
       Description: CloudKnox Control Tower Lifecycle Event Lambda
       Handler: CloudKnox_TriggerLifecycleEvent.lambda_handler
       MemorySize: 256
-      Runtime: python3.7
+      Runtime: python3.10
       Environment:
         Variables:
           CloudKnoxSentryAccountId : !Ref CloudKnoxSentryAccountId


### PR DESCRIPTION
CloudFormation templates in aws-integrations-for-cloudknox have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (python3.7). The affected templates have been updated to a supported runtime (python3.10).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.